### PR TITLE
Update links to Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,5 +4,5 @@ As contributors and maintainers of this project, we pledge to follow the [Carpen
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by following our [reporting guidelines][coc-reporting].
 
-[coc-reporting]: https://docs.carpentries.org/topic_folders/policies/incident-reporting.html
-[coc]: https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html
+[coc-reporting]: https://docs.carpentries.org/policies/coc/incident-reporting.html
+[coc]: https://docs.carpentries.org/policies/coc/


### PR DESCRIPTION
The same change should be applied across the other Carpentries organizations. Please let me know if a PR in swcarpentry for example would be helpful.